### PR TITLE
Fix search error

### DIFF
--- a/src/entities/Search/model/searchSlice.ts
+++ b/src/entities/Search/model/searchSlice.ts
@@ -12,7 +12,7 @@ const searchSlice = createSlice({
     },
     reducers: {
         setSearchValue(state, action: PayloadAction<SearchType>) {
-            if (action.payload) state.value = action.payload.value;
+            if (action.payload) state.value = action.payload.value.toLowerCase();
         }
     }
 });

--- a/src/entities/Search/tests/searchSlice.test.ts
+++ b/src/entities/Search/tests/searchSlice.test.ts
@@ -8,8 +8,8 @@ describe('Testing searchSlice', () => {
         expect(result).toEqual({ value: '' });
     });
 
-    test('should set value at state that is passed by action', () => {
-        const action = { type: setSearchValue.type, payload: { value: 'some todo' }};
+    test('should set value at state that is passed by action and set value string in lower case', () => {
+        const action = { type: setSearchValue.type, payload: { value: 'Some todo' }};
 
         const result = searchReducer({ value: '' }, action);
 

--- a/src/entities/Todo/model/todoSlice.ts
+++ b/src/entities/Todo/model/todoSlice.ts
@@ -12,7 +12,7 @@ const todoSlice = createSlice({
         addTodo(state, action: PayloadAction<{ text: string }>) {
             state.todoList?.push({
                 id: Math.random(),
-                text: action.payload.text,
+                text: action.payload.text.toLowerCase(),
                 status: false,
             });
             if (state.todoList) setDataToLocalStorage<TodoItem[]>(state.todoList, 'todos');

--- a/src/entities/Todo/tests/todoSlice.test.ts
+++ b/src/entities/Todo/tests/todoSlice.test.ts
@@ -15,8 +15,8 @@ describe('Testing todoSlice', () => {
         expect(result).toEqual({ todoList: [] });
     });
 
-    test('should add new todo to state that is passed by action', () => {
-        const todo = { id: 1, text: 'first todo', status: false };
+    test('should add new todo to state that is passed by action and set text string to lower case', () => {
+        const todo = { id: 1, text: 'First Todo', status: false };
         const action = { type: addTodo.type, payload: { text: todo.text }};
         const result = todoReducer({ todoList: [] }, action);
 


### PR DESCRIPTION
When some one added new todo this one can entered string in lower case or upper case. An action of todo slice added this string without changes. When this one entry same string into search input in other case the search couldn't find todo enty though there was this entry into state.

To do the search more comfortable I added string convering into lower case at search and todo slices and I added changes into its test files to they check string convering too.